### PR TITLE
Add possibility to input multiple sentences

### DIFF
--- a/lm_scorer/models/abc/base.py
+++ b/lm_scorer/models/abc/base.py
@@ -71,9 +71,10 @@ class LMScorer(ABC):
     ]:
         sentences = [text] if isinstance(text, str) else text
         outputs = []
-        for scores, ids, tokens in self._tokens_log_prob(sentences):
+        for log_probs, ids, tokens in self._tokens_log_prob(sentences):
+            scores = log_probs  # type: torch.Tensor # type: ignore
             if not log:
-                scores = scores.exp()  # type: torch.Tensor # type: ignore
+                scores = scores.exp()
             outputs.append((scores.tolist(), ids.tolist(), tokens))
 
         return outputs[0] if isinstance(text, str) else outputs

--- a/lm_scorer/models/abc/base.py
+++ b/lm_scorer/models/abc/base.py
@@ -70,16 +70,13 @@ class LMScorer(ABC):
         List[Tuple[List[float], List[int], List[str]]],
     ]:
         sentences = [text] if isinstance(text, str) else text
-        outputs = [
-            (
-                log_probs.exp().tolist() if not log else log_probs.tolist(),
-                ids.tolist(),
-                tokens,
-            )
-            for log_probs, ids, tokens in self._tokens_log_prob(sentences)
-        ]
+        outputs = []
+        for scores, ids, tokens in self._tokens_log_prob(sentences):
+            if not log:
+                scores = scores.exp()  # type: torch.Tensor # type: ignore
+            outputs.append((scores.tolist(), ids.tolist(), tokens))
 
-        return outputs[0] if isinstance(text, str) else text
+        return outputs[0] if isinstance(text, str) else outputs
 
     @classmethod
     def supported_model_names(cls) -> Iterable[str]:

--- a/lm_scorer/models/abc/base.py
+++ b/lm_scorer/models/abc/base.py
@@ -27,7 +27,7 @@ class LMScorer(ABC):
     ) -> Union[float, List[float]]:
         sentences = [text] if isinstance(text, str) else text
         if len(sentences) == 0:
-            raise ValueError("Try to score a empty list of sentences")
+            return []
 
         outputs = self._tokens_log_prob(sentences)
 
@@ -74,7 +74,7 @@ class LMScorer(ABC):
     ]:
         sentences = [text] if isinstance(text, str) else text
         if len(sentences) == 0:
-            raise ValueError("Try to score a empty list of sentences")
+            return []
         outputs = []
         for log_probs, ids, tokens in self._tokens_log_prob(sentences):
             scores = log_probs  # type: torch.Tensor # type: ignore

--- a/lm_scorer/models/abc/base.py
+++ b/lm_scorer/models/abc/base.py
@@ -26,6 +26,9 @@ class LMScorer(ABC):
         self, text: Union[str, List[str]], log: bool = False, reduce: str = "prod",
     ) -> Union[float, List[float]]:
         sentences = [text] if isinstance(text, str) else text
+        if len(sentences) == 0:
+            raise ValueError("Try to score a empty list of sentences")
+
         outputs = self._tokens_log_prob(sentences)
 
         scores = []
@@ -70,6 +73,8 @@ class LMScorer(ABC):
         List[Tuple[List[float], List[int], List[str]]],
     ]:
         sentences = [text] if isinstance(text, str) else text
+        if len(sentences) == 0:
+            raise ValueError("Try to score a empty list of sentences")
         outputs = []
         for log_probs, ids, tokens in self._tokens_log_prob(sentences):
             scores = log_probs  # type: torch.Tensor # type: ignore

--- a/lm_scorer/models/abc/base.py
+++ b/lm_scorer/models/abc/base.py
@@ -94,7 +94,7 @@ class LMScorer(ABC):
 
     @abstractmethod
     def _tokens_log_prob(
-        self, sentences: List[str]
+        self, text: List[str]
     ) -> List[Tuple[torch.FloatTensor, torch.LongTensor, List[str]]]:
         ...  # pragma: no cover
 

--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -1,5 +1,5 @@
 from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from torch.nn.utils.rnn import pad_sequence
+
 
 import torch
 from transformers import GPT2Tokenizer, GPT2LMHeadModel
@@ -22,11 +22,17 @@ class GPT2LMScorer(TransformersLMScorer):
         self.batch_size = options["batch_size"] if "batch_size" in options else 1
 
     def add_special_tokens_and_encode(self, text):
-        return self.tokenizer.encode(self.tokenizer.bos_token + text + self.tokenizer.eos_token)
+        return self.tokenizer.encode(
+            self.tokenizer.bos_token + text + self.tokenizer.eos_token
+        )
 
     def pad(self, sequences: List[torch.Tensor]):
         max_seq_len = max([s.size(0) for s in sequences])
-        out_tensor = sequences[0].data.new(len(sequences), max_seq_len).fill_(self.tokenizer.eos_token_id)
+        out_tensor = (
+            sequences[0]
+            .data.new_zeros(len(sequences), max_seq_len)
+            .fill_(self.tokenizer.eos_token_id)
+        )
         mask = torch.zeros((len(sequences), max_seq_len), device=sequences[0].device)
         for i, tensor in enumerate(sequences):
             length = tensor.size(0)
@@ -36,13 +42,24 @@ class GPT2LMScorer(TransformersLMScorer):
         return out_tensor, mask
 
     def _tokens_log_prob_single_batch(
-            self, sentences: List[str]
+        self, sentences: List[str]
     ) -> List[Tuple[torch.FloatTensor, torch.LongTensor, List[str]]]:
 
         device = self.model.device
 
-        tokens = [self.add_special_tokens_and_encode(sentence) for sentence in sentences]
-        ids, mask = self.pad(list(map(lambda x: torch.tensor(x, device=device, dtype=torch.long), tokens)))
+        tokens = [
+            self.add_special_tokens_and_encode(sentence) for sentence in sentences
+        ]
+        ids, mask = self.pad(
+            list(
+                map(
+                    lambda x: torch.tensor(  # pylint: disable=not-callable
+                        x, device=device, dtype=torch.long
+                    ),
+                    tokens,
+                )
+            )
+        )
 
         with torch.no_grad():
             outputs = self.model(ids)
@@ -64,14 +81,24 @@ class GPT2LMScorer(TransformersLMScorer):
         # log_prob.shape = [nb_sentences, max_seq_len]
         log_probs = ids_scores - pred_scores.logsumexp(2)
 
-        return [(log_probs[i, :len(tokens[i])], ids[i, :len(tokens[i])], tokens[i]) for i in range(len(sentences))]
+        return [
+            (log_probs[i, : len(tokens[i])], ids[i, : len(tokens[i])], tokens[i][1:])
+            for i in range(len(sentences))
+        ]  # type: ignore
 
-    def _tokens_log_prob(self, sentences):
+    def _tokens_log_prob(
+        self, sentences: List[str]
+    ) -> List[Tuple[torch.FloatTensor, torch.LongTensor, List[str]]]:
+
         output = []
         for i in range(len(sentences) // self.batch_size):
-            output += self._tokens_log_prob_single_batch(sentences[i * self.batch_size: (i+1) * self.batch_size])
+            output += self._tokens_log_prob_single_batch(
+                sentences[i * self.batch_size : (i + 1) * self.batch_size]
+            )
         if len(sentences) % self.batch_size != 0:
-            output += self._tokens_log_prob_single_batch(sentences[- (len(sentences) % self.batch_size):])
+            output += self._tokens_log_prob_single_batch(
+                sentences[-(len(sentences) % self.batch_size) :]
+            )
         return output
 
     # @overrides_tokens_log_prob_single_batch

--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -91,14 +91,14 @@ class GPT2LMScorer(TransformersLMScorer):
     ) -> List[Tuple[torch.FloatTensor, torch.LongTensor, List[str]]]:
 
         output = []
-        for i in range(len(sentences) // self.batch_size):
-            output += self._tokens_log_prob_single_batch(
-                sentences[i * self.batch_size : (i + 1) * self.batch_size]
-            )
+        for i in range(0, len(sentences), self.batch_size):
+            batch = sentences[i : i + self.batch_size]
+            output += self._tokens_log_prob_single_batch(batch)
+
         if len(sentences) % self.batch_size != 0:
-            output += self._tokens_log_prob_single_batch(
-                sentences[-(len(sentences) % self.batch_size) :]
-            )
+            remaining_batch = sentences[-(len(sentences) % self.batch_size) :]
+            output += self._tokens_log_prob_single_batch(remaining_batch)
+
         return output
 
     # @overrides_tokens_log_prob_single_batch

--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -1,6 +1,5 @@
 from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
-
 import torch
 from transformers import GPT2Tokenizer, GPT2LMHeadModel
 
@@ -19,89 +18,53 @@ class GPT2LMScorer(TransformersLMScorer):
         if "device" in options:
             self.model.to(options["device"])
 
-        self.batch_size = options["batch_size"] if "batch_size" in options else 1
-
-    def add_special_tokens_and_encode(self, text):
-        return self.tokenizer.encode(
-            self.tokenizer.bos_token + text + self.tokenizer.eos_token
-        )
-
-    def pad(self, sequences: List[torch.Tensor]):
-        max_seq_len = max([s.size(0) for s in sequences])
-        out_tensor = (
-            sequences[0]
-            .data.new_zeros(len(sequences), max_seq_len)
-            .fill_(self.tokenizer.eos_token_id)
-        )
-        mask = torch.zeros((len(sequences), max_seq_len), device=sequences[0].device)
-        for i, tensor in enumerate(sequences):
-            length = tensor.size(0)
-            out_tensor[i, :length] = tensor
-            mask[i, :length] = 1
-
-        return out_tensor, mask
-
-    def _tokens_log_prob_single_batch(
-        self, sentences: List[str]
-    ) -> List[Tuple[torch.FloatTensor, torch.LongTensor, List[str]]]:
-
+    # @overrides
+    def _tokens_log_prob_single_sentence(
+        self, text: str
+    ) -> Tuple[torch.FloatTensor, torch.LongTensor, List[str]]:
         device = self.model.device
-
-        tokens = [
-            self.add_special_tokens_and_encode(sentence) for sentence in sentences
-        ]
-        ids, mask = self.pad(
-            list(
-                map(
-                    lambda x: torch.tensor(  # pylint: disable=not-callable
-                        x, device=device, dtype=torch.long
-                    ),
-                    tokens,
-                )
-            )
+        input_text = "%s%s%s" % (
+            self.tokenizer.bos_token,
+            text,
+            self.tokenizer.eos_token,
+        )
+        # len(tokens) = seq_len + 2
+        tokens = self.tokenizer.tokenize(input_text)
+        # ids.shape = [1, seq_len + 2]
+        ids = torch.tensor(  # pylint: disable=not-callable
+            [self.tokenizer.convert_tokens_to_ids(tokens)],
+            device=device,
+            dtype=torch.long,
         )
 
         with torch.no_grad():
             outputs = self.model(ids)
 
-        # pred_scores.shape = [nb_sentences, max_seq_len, vocab_size]
+        # pred_scores.shape = [1, seq_len + 2, vocab_size]
         pred_scores = outputs[0]
 
-        # Align input and target
+        # len(tokens) = seq_len + 1
+        tokens = tokens[1:]
+        # ids.shape = [1, seq_len + 1, vocab_size]
         ids = ids[:, 1:]
+        # pred_scores.shape = [1, seq_len + 1, vocab_size]
         pred_scores = pred_scores[:, :-1, :]
 
-        # Retrieve the token scores corresponding to the target id
-        # ids_scores.shape = [nb_sentences, max_seq_len]
+        # ids_scores.shape = [1, seq_len + 1]
         ids_scores = pred_scores.gather(2, ids.unsqueeze(2)).squeeze(2)
-
-        # Zero the values of the padding inputs
-        ids_scores *= mask[:, 1:]
-
-        # log_prob.shape = [nb_sentences, max_seq_len]
+        # log_prob.shape = [1, seq_len + 1]
         log_probs = ids_scores - pred_scores.logsumexp(2)
 
-        return [
-            (log_probs[i, : len(tokens[i])], ids[i, : len(tokens[i])], tokens[i][1:])
-            for i in range(len(sentences))
-        ]  # type: ignore
+        return log_probs[0], ids[0], tokens  # type: ignore
 
     def _tokens_log_prob(
         self, sentences: List[str]
     ) -> List[Tuple[torch.FloatTensor, torch.LongTensor, List[str]]]:
+        return [
+            self._tokens_log_prob_single_sentence(sentence) for sentence in sentences
+        ]
 
-        output = []
-        for i in range(0, len(sentences), self.batch_size):
-            batch = sentences[i : i + self.batch_size]
-            output += self._tokens_log_prob_single_batch(batch)
-
-        if len(sentences) % self.batch_size != 0:
-            remaining_batch = sentences[-(len(sentences) % self.batch_size) :]
-            output += self._tokens_log_prob_single_batch(remaining_batch)
-
-        return output
-
-    # @overrides_tokens_log_prob_single_batch
+    # @overrides
     @classmethod
     def _supported_model_names(cls) -> Iterable[str]:
         return GPT2LMHeadModel.pretrained_model_archive_map.keys()

--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -1,4 +1,5 @@
 from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from torch.nn.utils.rnn import pad_sequence
 
 import torch
 from transformers import GPT2Tokenizer, GPT2LMHeadModel
@@ -18,46 +19,62 @@ class GPT2LMScorer(TransformersLMScorer):
         if "device" in options:
             self.model.to(options["device"])
 
-    # @overrides
-    def _tokens_log_prob(
-        self, text: str
-    ) -> Tuple[torch.FloatTensor, torch.LongTensor, List[str]]:
+        self.batch_size = options["batch_size"] if "batch_size" in options else 1
+
+    def add_special_tokens_and_encode(self, text):
+        return self.tokenizer.encode(self.tokenizer.bos_token + text + self.tokenizer.eos_token)
+
+    def pad(self, sequences: List[torch.Tensor]):
+        max_seq_len = max([s.size(0) for s in sequences])
+        out_tensor = sequences[0].data.new(len(sequences), max_seq_len).fill_(self.tokenizer.eos_token_id)
+        mask = torch.zeros((len(sequences), max_seq_len), device=sequences[0].device)
+        for i, tensor in enumerate(sequences):
+            length = tensor.size(0)
+            out_tensor[i, :length] = tensor
+            mask[i, :length] = 1
+
+        return out_tensor, mask
+
+    def _tokens_log_prob_single_batch(
+            self, sentences: List[str]
+    ) -> List[Tuple[torch.FloatTensor, torch.LongTensor, List[str]]]:
+
         device = self.model.device
-        input_text = "%s%s%s" % (
-            self.tokenizer.bos_token,
-            text,
-            self.tokenizer.eos_token,
-        )
-        # len(tokens) = seq_len + 2
-        tokens = self.tokenizer.tokenize(input_text)
-        # ids.shape = [1, seq_len + 2]
-        ids = torch.tensor(  # pylint: disable=not-callable
-            [self.tokenizer.convert_tokens_to_ids(tokens)],
-            device=device,
-            dtype=torch.long,
-        )
+
+        tokens = [self.add_special_tokens_and_encode(sentence) for sentence in sentences]
+        ids, mask = self.pad(list(map(lambda x: torch.tensor(x, device=device, dtype=torch.long), tokens)))
 
         with torch.no_grad():
             outputs = self.model(ids)
 
-        # pred_scores.shape = [1, seq_len + 2, vocab_size]
+        # pred_scores.shape = [nb_sentences, max_seq_len, vocab_size]
         pred_scores = outputs[0]
 
-        # len(tokens) = seq_len + 1
-        tokens = tokens[1:]
-        # ids.shape = [1, seq_len + 1, vocab_size]
+        # Align input and target
         ids = ids[:, 1:]
-        # pred_scores.shape = [1, seq_len + 1, vocab_size]
         pred_scores = pred_scores[:, :-1, :]
 
-        # ids_scores.shape = [1, seq_len + 1]
+        # Retrieve the token scores corresponding to the target id
+        # ids_scores.shape = [nb_sentences, max_seq_len]
         ids_scores = pred_scores.gather(2, ids.unsqueeze(2)).squeeze(2)
-        # log_prob.shape = [1, seq_len + 1]
+
+        # Zero the values of the padding inputs
+        ids_scores *= mask[:, 1:]
+
+        # log_prob.shape = [nb_sentences, max_seq_len]
         log_probs = ids_scores - pred_scores.logsumexp(2)
 
-        return log_probs[0], ids[0], tokens  # type: ignore
+        return [(log_probs[i, :len(tokens[i])], ids[i, :len(tokens[i])], tokens[i]) for i in range(len(sentences))]
 
-    # @overrides
+    def _tokens_log_prob(self, sentences):
+        output = []
+        for i in range(len(sentences) // self.batch_size):
+            output += self._tokens_log_prob_single_batch(sentences[i * self.batch_size: (i+1) * self.batch_size])
+        if len(sentences) % self.batch_size != 0:
+            output += self._tokens_log_prob_single_batch(sentences[- (len(sentences) % self.batch_size):])
+        return output
+
+    # @overrides_tokens_log_prob_single_batch
     @classmethod
     def _supported_model_names(cls) -> Iterable[str]:
         return GPT2LMHeadModel.pretrained_model_archive_map.keys()

--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -58,11 +58,9 @@ class GPT2LMScorer(TransformersLMScorer):
         return log_probs[0], ids[0], tokens  # type: ignore
 
     def _tokens_log_prob(
-        self, sentences: List[str]
+        self, text: List[str]
     ) -> List[Tuple[torch.FloatTensor, torch.LongTensor, List[str]]]:
-        return [
-            self._tokens_log_prob_single_sentence(sentence) for sentence in sentences
-        ]
+        return list(map(self._tokens_log_prob_single_sentence, text))
 
     # @overrides
     @classmethod

--- a/tests/models/test_gpt2.py
+++ b/tests/models/test_gpt2.py
@@ -51,6 +51,22 @@ def describe_sentence_score():
         score = scorer.sentence_score("", reduce="hmean", log=True)
         assert score <= 0.0
 
+    def should_throw_an_exception_for_empty_list():
+        with pytest.raises(ValueError):
+            scorer.sentence_score([])
+
+    def should_give_same_results_independently_of_input_type():
+        sentences = [
+            "I have a big amount of money.",
+            "This is the best day of my life.",
+            "I think this game is easier than the one we played yesterday.",
+        ]
+
+        sentences_scores = scorer.sentence_score(sentences)
+
+        for i, sentence in enumerate(sentences):
+            assert scorer.sentence_score(sentence) == sentences_scores[i]
+
     # TODO: Test the various reducing strategies by mocking the _tokens_log_prob call.
 
 
@@ -69,6 +85,10 @@ def describe_tokens_score():
         assert len(ids) == 1, ids
         assert len(tokens) == 1, tokens
         assert scores[0] <= 0.0
+
+    def should_throw_an_exception_for_empty_list():
+        with pytest.raises(ValueError):
+            scorer.sentence_score([])
 
 
 def describe_sentence_score_for_english():

--- a/tests/models/test_gpt2.py
+++ b/tests/models/test_gpt2.py
@@ -52,7 +52,7 @@ def describe_sentence_score():
         assert score <= 0.0
 
     def should_work_on_an_empty_list():
-        scorer.sentence_score([])
+        assert scorer.sentence_score([]) == []
 
     def should_give_same_results_independently_of_input_type():
         sentences = [

--- a/tests/models/test_gpt2.py
+++ b/tests/models/test_gpt2.py
@@ -51,9 +51,8 @@ def describe_sentence_score():
         score = scorer.sentence_score("", reduce="hmean", log=True)
         assert score <= 0.0
 
-    def should_throw_an_exception_for_empty_list():
-        with pytest.raises(ValueError):
-            scorer.sentence_score([])
+    def should_work_on_an_empty_list():
+        scorer.sentence_score([])
 
     def should_give_same_results_independently_of_input_type():
         sentences = [
@@ -86,9 +85,8 @@ def describe_tokens_score():
         assert len(tokens) == 1, tokens
         assert scores[0] <= 0.0
 
-    def should_throw_an_exception_for_empty_list():
-        with pytest.raises(ValueError):
-            scorer.sentence_score([])
+    def should_work_on_an_empty_list():
+        scorer.tokens_score([])
 
 
 def describe_sentence_score_for_english():

--- a/tests/models/test_gpt2.py
+++ b/tests/models/test_gpt2.py
@@ -86,7 +86,7 @@ def describe_tokens_score():
         assert scores[0] <= 0.0
 
     def should_work_on_an_empty_list():
-        scorer.tokens_score([])
+        assert scorer.tokens_score([]) == []
 
 
 def describe_sentence_score_for_english():


### PR DESCRIPTION
In order to be able to fully benefit from parallelization, I propose to add the possibility to input the sentences into the transformer models by batch. 

The work is not finished yet and I still have to pass the CI test (I will proceed as you suggest in #3) but it is working and would like to have your opinion before going further. 

In order to make minimal change to your code, for now tokens_score return a list of log_probs, ids, tokens (one item for each sentence). However, it would be much more efficient to make the reduction when we still have the log_probs scores as a tensor. One possibility would be that _tokens_log_prob now return a tensor of shape (number sentences, max sentences length). What do you think of that ?

Also, I did not use the pad_sequence function from torch.nn.utils.rnn but recode it in order that it returns a mask (with 1 at the place of the padding value) which is useful latter in the code to remove the score from padding value. I think this function should not be in GPT2LMScorer class but somewhere else. 