### PR TITLE
Restore compatibility with current Python, torch and transformers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,23 +12,21 @@ jobs:
     name: Black & Pylint & Mypy
     steps:
       - name: Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.13'
       - name: Install dependencies
         run: |
-          python -m pip install -qq --upgrade pip
-          pip install -qq poetry
+          python -m pip install --upgrade pip
+          pip install poetry
           poetry install
       - name: Check if files are correctly formatted with black
-        run: |
-          poetry run task format --check --diff
+        run: poetry run task format --check --diff
       - name: Lint with pylint
         run: |
           poetry run task lint --disable=E --exit-zero
           poetry run task lint -E
       - name: Perform static type checking with mypy
-        run: |
-          poetry run task types
+        run: poetry run task types

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -13,27 +13,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: ['3.11', '3.12', '3.13']
+    env:
+      HF_HOME: ${{ github.workspace }}/.hf_home
     steps:
       - name: Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up huggingface transformers pre-trained models cache
-        uses: actions/cache@v1
+      - name: Cache huggingface models
+        uses: actions/cache@v4
         with:
-          path: .transformers_cache
-          key: transformers_cache
-          restore-keys: transformers_cache
+          path: ${{ github.workspace }}/.hf_home
+          key: hf-home-${{ runner.os }}
       - name: Install poetry
         run: |
-          python -m pip install -qq --upgrade pip
-          pip install -qq poetry
+          python -m pip install --upgrade pip
+          pip install poetry
       - name: Install dependencies
-        run: |
-          poetry install
+        run: poetry install
       - name: Test with pytest
-        run: |
-          poetry run task test
+        run: poetry run task test

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -13,27 +13,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: ['3.11', '3.12', '3.13']
+    env:
+      HF_HOME: ${{ github.workspace }}/.hf_home
     steps:
       - name: Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up huggingface transformers pre-trained models cache
-        uses: actions/cache@v1
+      - name: Cache huggingface models
+        uses: actions/cache@v4
         with:
-          path: .transformers_cache
-          key: transformers_cache
-          restore-keys: transformers_cache
+          path: ${{ github.workspace }}/.hf_home
+          key: hf-home-${{ runner.os }}
       - name: Install poetry
         run: |
-          python -m pip install -qq --upgrade pip
-          pip install -qq poetry
+          python -m pip install --upgrade pip
+          pip install poetry
       - name: Install dependencies
-        run: |
-          poetry install
+        run: poetry install
       - name: Test with pytest
-        run: |
-          poetry run task test
+        run: poetry run task test

--- a/lm_scorer/models/abc/base.py
+++ b/lm_scorer/models/abc/base.py
@@ -13,17 +13,18 @@ class LMScorer(ABC):
     @overload
     def sentence_score(
         self, text: str, log: bool = False, reduce: str = "prod"
-    ) -> float:
-        ...
+    ) -> float: ...
 
     @overload
     def sentence_score(
         self, text: List[str], log: bool = False, reduce: str = "prod"
-    ) -> List[float]:
-        ...
+    ) -> List[float]: ...
 
     def sentence_score(
-        self, text: Union[str, List[str]], log: bool = False, reduce: str = "prod",
+        self,
+        text: Union[str, List[str]],
+        log: bool = False,
+        reduce: str = "prod",
     ) -> Union[float, List[float]]:
         sentences = [text] if isinstance(text, str) else text
         scores: List[float] = []
@@ -55,18 +56,14 @@ class LMScorer(ABC):
     @overload
     def tokens_score(
         self, text: str, log: bool = False
-    ) -> Tuple[List[float], List[int], List[str]]:
-        ...
+    ) -> Tuple[List[float], List[int], List[str]]: ...
 
     @overload
     def tokens_score(
         self, text: List[str], log: bool = False
-    ) -> List[Tuple[List[float], List[int], List[str]]]:
-        ...
+    ) -> List[Tuple[List[float], List[int], List[str]]]: ...
 
-    def tokens_score(
-        self, text: Union[str, List[str]], log: bool = False
-    ) -> Union[
+    def tokens_score(self, text: Union[str, List[str]], log: bool = False) -> Union[
         Tuple[List[float], List[int], List[str]],
         List[Tuple[List[float], List[int], List[str]]],
     ]:
@@ -94,10 +91,10 @@ class LMScorer(ABC):
     @abstractmethod
     def _tokens_log_prob(
         self, text: List[str]
-    ) -> List[Tuple[torch.DoubleTensor, torch.LongTensor, List[str]]]:
-        ...  # pragma: no cover
+    ) -> List[
+        Tuple[torch.DoubleTensor, torch.LongTensor, List[str]]
+    ]: ...  # pragma: no cover
 
     @classmethod
     @abstractmethod
-    def _supported_model_names(cls) -> Iterable[str]:
-        ...  # pragma: no cover
+    def _supported_model_names(cls) -> Iterable[str]: ...  # pragma: no cover

--- a/lm_scorer/models/abc/batch.py
+++ b/lm_scorer/models/abc/batch.py
@@ -31,5 +31,6 @@ class BatchedLMScorer(LMScorer):
     @abstractmethod
     def _tokens_log_prob_for_batch(
         self, text: List[str]
-    ) -> List[Tuple[torch.DoubleTensor, torch.LongTensor, List[str]]]:
-        ...  # pragma: no cover
+    ) -> List[
+        Tuple[torch.DoubleTensor, torch.LongTensor, List[str]]
+    ]: ...  # pragma: no cover

--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -3,8 +3,7 @@ from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 import torch
 from transformers import AutoTokenizer, GPT2LMHeadModel
-from transformers import GPT2_PRETRAINED_CONFIG_ARCHIVE_MAP
-from transformers.tokenization_utils import BatchEncoding
+from transformers import BatchEncoding
 
 from .abc.transformers import TransformersLMScorer
 
@@ -15,9 +14,7 @@ class GPT2LMScorer(TransformersLMScorer):
         super()._build(model_name, options)
 
         # pylint: disable=attribute-defined-outside-init
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, use_fast=True, add_special_tokens=False
-        )
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
         # Add the pad token to GPT2 dictionary.
         # len(tokenizer) = vocab_size + 1
         self.tokenizer.add_special_tokens({"additional_special_tokens": ["<|pad|>"]})
@@ -43,8 +40,10 @@ class GPT2LMScorer(TransformersLMScorer):
 
         # TODO: Handle overflowing elements for long sentences
         text = list(map(self._add_special_tokens, text))
-        encoding: BatchEncoding = self.tokenizer.batch_encode_plus(
-            text, return_tensors="pt",
+        encoding: BatchEncoding = self.tokenizer(
+            text,
+            return_tensors="pt",
+            padding=True,
         )
         with torch.no_grad():
             ids = encoding["input_ids"].to(self.model.device)
@@ -82,4 +81,4 @@ class GPT2LMScorer(TransformersLMScorer):
     # @overrides
     @classmethod
     def _supported_model_names(cls) -> Iterable[str]:
-        return GPT2_PRETRAINED_CONFIG_ARCHIVE_MAP.keys()
+        return ["gpt2", "gpt2-medium", "gpt2-large", "gpt2-xl", "distilgpt2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lm-scorer"
-version = "0.4.2"
+version = "0.5.0"
 description = "Language Model based sentences scoring library"
 authors = ["Simone Primarosa <simonepri@outlook.com>"]
 license = "MIT"
@@ -18,30 +18,29 @@ packages = [
 lm-scorer = 'lm_scorer.bin.cli:run'
 
 [tool.taskipy.tasks]
-lint = "python -m pylint lm_scorer tests -v --output-format colorized --disable duplicate-code,bad-continuation --generated-members=torch.*"
+lint = "python -m pylint lm_scorer tests -v --output-format colorized --disable duplicate-code --generated-members=torch.*"
 types = "python -m mypy lm_scorer tests --ignore-missing-imports"
 format = "python -m black lm_scorer tests"
 test = "python -m pytest --cov=lm_scorer tests --verbose"
 
 [tool.poetry.dependencies]
-python = ">=3.6,<3.8"
-pip = ">=20.0.0"
-transformers = "^2.9.0"
-torch = "^1.4.0"
+python = ">=3.11,<4.0"
+transformers = ">=4.30,<6"
+torch = "^2.2"
 
 [tool.poetry.dev-dependencies]
-taskipy = "^1.2.1"
-black = "~19.10b0"
-pylint = "^2.5.2"
-mypy = "~0.770"
-pytest = "^5.4.2"
-pytest-cov = "^2.8.1"
-pytest-mock = "^3.0.0"
-pytest-sugar = "~0.9.3"
-pytest-describe = "^1.0.0"
-scipy = "^1.4.1"
-torch = "^1.4.0"
+taskipy = "^1.12"
+black = "^26.0"
+pylint = "^3.1"
+mypy = "^1.9"
+pytest = "^8.1"
+pytest-cov = "^5.0"
+pytest-mock = "^3.14"
+pytest-sugar = "^1.0"
+pytest-describe = "^2.2"
+scipy = "^1.11"
+torch = "^2.2"
 
 [build-system]
-requires = ["poetry >=1,<2"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/readme.md
+++ b/readme.md
@@ -11,16 +11,16 @@
   </a>
   <br />
   <!-- Lint -->
-  <a href="https://github.com/simonepri/lm-scorer/actions?query=workflow:lint+branch:master">
-    <img src="https://github.com/simonepri/lm-scorer/workflows/lint/badge.svg?branch=master" alt="Lint status" />
+  <a href="https://github.com/simonepri/lm-scorer/actions/workflows/lint.yml">
+    <img src="https://github.com/simonepri/lm-scorer/actions/workflows/lint.yml/badge.svg" alt="Lint status" />
   </a>
   <!-- Test - macOS -->
-  <a href="https://github.com/simonepri/lm-scorer/actions?query=workflow:test-macos+branch:master">
-    <img src="https://github.com/simonepri/lm-scorer/workflows/test-macos/badge.svg?branch=master" alt="Test macOS status" />
+  <a href="https://github.com/simonepri/lm-scorer/actions/workflows/test-macos.yml">
+    <img src="https://github.com/simonepri/lm-scorer/actions/workflows/test-macos.yml/badge.svg" alt="Test macOS status" />
   </a>
   <!-- Test - Ubuntu -->
-  <a href="https://github.com/simonepri/lm-scorer/actions?query=workflow:test-ubuntu+branch:master">
-    <img src="https://github.com/simonepri/lm-scorer/workflows/test-ubuntu/badge.svg?branch=master" alt="Test Ubuntu status" />
+  <a href="https://github.com/simonepri/lm-scorer/actions/workflows/test-ubuntu.yml">
+    <img src="https://github.com/simonepri/lm-scorer/actions/workflows/test-ubuntu.yml/badge.svg" alt="Test Ubuntu status" />
   </a>
   <br />
   <!-- Code style -->
@@ -50,7 +50,7 @@
   <br />
   <!-- License -->
   <a href="https://github.com/simonepri/lm-scorer/tree/master/license">
-    <img src="https://img.shields.io/github/license/simonepri/lm-scorer.svg" alt="Project license" />
+    <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Project license" />
   </a>
   <!-- DOI -->
   <a href="https://doi.org/10.5281/zenodo.20584992">

--- a/tests/integration/test_gpt2.py
+++ b/tests/integration/test_gpt2.py
@@ -45,7 +45,10 @@ def describe_sentence_score_for_english():
     def should_give_lower_score_to_sentences_with_adverbs_errors():
         # ERRANT - ADV error
         sentence_pairs = [
-            ("Let us finish this quickly!", "Let us finish this speedily!",),
+            (
+                "Let us finish this quickly!",
+                "Let us finish this speedily!",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
@@ -70,16 +73,28 @@ def describe_sentence_score_for_english():
                 "The restaurant is in the middle of my home town.",
                 "The restaurant is in the middle of the my home town.",
             ),
-            ("I am Italian.", "I am a Italian.",),
-            ("I am a teacher.", "I am teacher.",),
-            ("She gave me some advice.", "She gave me an advice.",),
+            (
+                "I am Italian.",
+                "I am a Italian.",
+            ),
+            (
+                "I am a teacher.",
+                "I am teacher.",
+            ),
+            (
+                "She gave me some advice.",
+                "She gave me an advice.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
     def should_give_lower_score_to_sentences_with_morphology_errors():
         # ERRANT - MORPH error
         sentence_pairs = [
-            ("I will quickly solve this.", "I will quick solve this.",),
+            (
+                "I will quickly solve this.",
+                "I will quick solve this.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
@@ -106,35 +121,50 @@ def describe_sentence_score_for_english():
     def should_give_lower_score_to_sentences_with_noun_number_errors():
         # ERRANT - NOUN:NUM error
         sentence_pairs = [
-            ("She has too many cats.", "She has too many cat.",),
+            (
+                "She has too many cats.",
+                "She has too many cat.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
     def should_give_lower_score_to_sentences_with_noun_possissive_errors():
         # ERRANT - NOUN:POSS error
         sentence_pairs = [
-            ("My friend's boss is leaving.", "My friends boss is leaving.",),
+            (
+                "My friend's boss is leaving.",
+                "My friends boss is leaving.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
     def should_give_lower_score_to_sentences_with_orthography_errors():
         # ERRANT - ORTH error
         sentence_pairs = [
-            ("You are my best friend.", "You are my bestfriend.",),
+            (
+                "You are my best friend.",
+                "You are my bestfriend.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
     def should_give_lower_score_to_sentences_with_particle_errors():
         # ERRANT - PART error
         sentence_pairs = [
-            ("Can you look at the kids?", "Can you look in the kids?",),
+            (
+                "Can you look at the kids?",
+                "Can you look in the kids?",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
     def should_give_lower_score_to_sentences_with_preposition_errors():
         # ERRANT - PREP error
         sentence_pairs = [
-            ("Can you look at them?", "Can you look in them?",),
+            (
+                "Can you look at them?",
+                "Can you look in them?",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
@@ -151,8 +181,14 @@ def describe_sentence_score_for_english():
     def should_give_lower_score_to_sentences_with_punctuation_errors():
         # ERRANT - PUNCT error
         sentence_pairs = [
-            ("I like dogs, cats, and dolphins.", "I like dogs cats and dolphins.",),
-            ("I can do this, but not now.", "I can do this but not now.",),
+            (
+                "I like dogs, cats, and dolphins.",
+                "I like dogs cats and dolphins.",
+            ),
+            (
+                "I can do this, but not now.",
+                "I can do this but not now.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
@@ -169,39 +205,69 @@ def describe_sentence_score_for_english():
     def should_give_lower_score_to_sentences_with_verb_errors():
         # ERRANT - VERB error
         sentence_pairs = [
-            ("I can walk there.", "I can ambulate there.",),
+            (
+                "I can walk there.",
+                "I can ambulate there.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
     def should_give_lower_score_to_sentences_with_verb_form_errors():
         # ERRANT - VERB:FORM error
         sentence_pairs = [
-            ("I danced yesterday.", "I dancing yesterday.",),
-            ("I am going to run a marathon.", "I am go to run a marathon.",),
-            ("I am going to run a marathon.", "I am going to running a marathon.",),
+            (
+                "I danced yesterday.",
+                "I dancing yesterday.",
+            ),
+            (
+                "I am going to run a marathon.",
+                "I am go to run a marathon.",
+            ),
+            (
+                "I am going to run a marathon.",
+                "I am going to running a marathon.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
     def should_give_lower_score_to_sentences_with_verb_inflection_errors():
         # ERRANT - VERB:INFL error
         sentence_pairs = [
-            ("I got arrested yesterday.", "I getted arrested yesterday.",),
-            ("You flipped the wrong coin.", "You fliped the wrong coin.",),
+            (
+                "I got arrested yesterday.",
+                "I getted arrested yesterday.",
+            ),
+            (
+                "You flipped the wrong coin.",
+                "You fliped the wrong coin.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
     def should_give_lower_score_to_sentences_with_verb_subj_agreement_errors():
         # ERRANT - VERB:SVA error
         sentence_pairs = [
-            ("I think he has the virus.", "I think he have the virus.",),
-            ("They said he is sick.", "They said he are sick.",),
+            (
+                "I think he has the virus.",
+                "I think he have the virus.",
+            ),
+            (
+                "They said he is sick.",
+                "They said he are sick.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)
 
     def should_give_lower_score_to_sentences_with_verb_tense_errors():
         # ERRANT - VERB:TENSE error
         sentence_pairs = [
-            ("He ate the pie yesterday.", "He eats the pie yesterday.",),
-            ("The pie was eaten by him yesterday.", "The pie eats by him yesterday.",),
+            (
+                "He ate the pie yesterday.",
+                "He eats the pie yesterday.",
+            ),
+            (
+                "The pie was eaten by him yesterday.",
+                "The pie eats by him yesterday.",
+            ),
         ]
         assert_score_of_sentence_pairs(scorer, sentence_pairs)

--- a/tests/unit/models/abc/test_base.py
+++ b/tests/unit/models/abc/test_base.py
@@ -2,7 +2,7 @@
 import math
 import pytest  # pylint: disable=unused-import
 
-import scipy
+import scipy.stats
 import torch
 from lm_scorer.models.abc.base import LMScorer
 


### PR DESCRIPTION
The old pins (python <3.8, transformers ^2.9, torch ^1.4) have no wheels for any current Python, so `pip install` just fails. This bumps them and fixes the transformers API changes that broke model loading and scoring.

- python >=3.11, transformers >=4.30,<6, torch ^2.2 (and drop the stray `pip` dep)
- gpt2.py: static model list (GPT2_PRETRAINED_CONFIG_ARCHIVE_MAP was removed), drop `add_special_tokens=`, use tokenizer `__call__` instead of the removed `batch_encode_plus`, fix the `BatchEncoding` import
- tests: `import scipy.stats` explicitly
- bump to 0.5.0

Tested in a Python 3.13 venv with both transformers 4.57 and 5.10: scoring, batching and token scores all match, unit tests pass.

Kept the cap at <6 rather than <5 since 4.x and 5.x both work, and pinning <5 is how this ended up stuck on transformers 2.x in the first place.

The old CI was red because it tested Python 3.6/3.7, which this drops, so it's updated here too:

- workflows: matrix to 3.11/3.12/3.13, current checkout/setup-python/cache actions, working model cache
- black reformat, drop the removed `bad-continuation` pylint option, poetry-core build backend
- refresh the README badges: modern Actions status badges + a static MIT license badge (GitHub wasn't detecting the license)

Closes #10, #11, #15, #16.
