### PR TITLE
Add bos/eos options to exclude special tokens from scoring

### DIFF
--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -14,6 +14,11 @@ class GPT2LMScorer(TransformersLMScorer):
         super()._build(model_name, options)
 
         # pylint: disable=attribute-defined-outside-init
+        # Whether to prepend/append the bos/eos tokens when scoring. Appending
+        # the eos token (the default) also scores the probability that the
+        # sentence ends; pass eos=False to omit it from the score (see #12).
+        self.add_bos = options.get("bos", True)
+        self.add_eos = options.get("eos", True)
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
         # Add the pad token to GPT2 dictionary.
         # len(tokenizer) = vocab_size + 1
@@ -28,7 +33,9 @@ class GPT2LMScorer(TransformersLMScorer):
             self.model.to(options["device"])
 
     def _add_special_tokens(self, text: str) -> str:
-        return self.tokenizer.bos_token + text + self.tokenizer.eos_token
+        bos = self.tokenizer.bos_token if self.add_bos else ""
+        eos = self.tokenizer.eos_token if self.add_eos else ""
+        return bos + text + eos
 
     # @overrides
     def _tokens_log_prob_for_batch(

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,11 @@ device = "cuda:0" if torch.cuda.is_available() else "cpu"
 batch_size = 1
 scorer = LMScorer.from_pretrained("gpt2", device=device, batch_size=batch_size)
 
+# By default the bos and eos (<|endoftext|>) tokens are added when scoring, so the
+# score includes the probability that the sentence ends where it does. Pass
+# eos=False (and/or bos=False) to exclude them:
+# scorer = LMScorer.from_pretrained("gpt2", device=device, eos=False)
+
 # Return token probabilities (provide log=True to return log probabilities)
 scorer.tokens_score("I like this package.")
 # => (scores, ids, tokens)

--- a/tests/unit/models/test_gpt2.py
+++ b/tests/unit/models/test_gpt2.py
@@ -129,3 +129,17 @@ def describe_tokens_log_prob_for_batch():
 
         assert ids == exp_ids
         assert tokens == exp_tokens
+
+
+def describe_special_tokens_options():
+    # pylint: disable=protected-access
+    def should_include_the_eos_token_by_default():
+        scorer = GPT2LMScorer("gpt2")
+        _, _, tokens = scorer._tokens_log_prob_for_batch(["Hello World!"])[0]
+        assert tokens[-1] == "<|endoftext|>"
+
+    def should_omit_the_eos_token_when_eos_is_false():
+        scorer = GPT2LMScorer("gpt2", eos=False)
+        _, _, tokens = scorer._tokens_log_prob_for_batch(["Hello World!"])[0]
+        assert "<|endoftext|>" not in tokens
+        assert tokens == ["Hello", "ĠWorld", "!"]


### PR DESCRIPTION
Adds optional `bos`/`eos` control to `GPT2LMScorer` so the trailing `<|endoftext|>` can be left out of the score (#12).

By default the eos token is appended and scored, so the score includes the probability that the sentence ends where it does — which, as #12 points out, depends on how text happened to be segmented during training. Pass `eos=False` (and/or `bos=False`) to omit them:

```python
scorer = LMScorer.from_pretrained("gpt2", eos=False)
```

Default stays `bos=True`/`eos=True`, so existing scores are unchanged — the exact gpt2 score tests still pass. Added a test and a README note.

Closes #12.
