### PR TITLE
Add release workflow to publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install poetry
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+      - name: Check tag matches package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(poetry version --short)"
+          if [ "$tag" != "$pkg" ]; then
+            echo "Release tag v$tag does not match pyproject version $pkg" >&2
+            exit 1
+          fi
+      - name: Build
+        run: poetry build
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: poetry publish


### PR DESCRIPTION
Adds a release workflow so new versions ship to PyPI automatically.

On a published GitHub Release it checks the tag matches the `pyproject` version, builds with poetry, and publishes to PyPI using a `PYPI_TOKEN` secret. Since this repo's Zenodo integration is enabled, creating the release also mints the version DOI — so one action does both.

To ship 0.5.0 after merging:

1. Create a PyPI API token scoped to the `lm-scorer` project and add it as a repo secret named `PYPI_TOKEN`.
2. Create a GitHub Release for tag `v0.5.0` targeting `master`.

That triggers this workflow (PyPI publish) and Zenodo (version DOI). Or publish once by hand with `poetry publish --build`.
