### PR TITLE
ci: use plain v-prefixed release tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
       "release-type": "python",
       "package-name": "lm-scorer",
       "bump-minor-pre-major": true,
-      "skip-changelog": true
+      "skip-changelog": true,
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
Adds `include-component-in-tag: false` to the release-please config so future releases are tagged `vX.Y.Z` instead of `lm-scorer-vX.Y.Z`, matching every prior release tag. The existing `lm-scorer-v0.5.0` tag is left as-is.