### PR TITLE
feat: forward extra from_pretrained kwargs to Hugging Face

### DIFF
--- a/lm_scorer/models/abc/transformers.py
+++ b/lm_scorer/models/abc/transformers.py
@@ -1,16 +1,6 @@
 # pylint: disable=abstract-method
-from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
-
-import os
-
 from .batch import BatchedLMScorer
 
 
 class TransformersLMScorer(BatchedLMScorer):
-    # @overrides
-    def _build(self, model_name: str, options: Dict[str, Any]) -> None:
-        super()._build(model_name, options)
-
-        #  Make transformers cache path configurable.
-        cache_dir = os.environ.get("TRANSFORMERS_CACHE_DIR", ".transformers_cache")
-        options["cache_dir"] = options.get("cache_dir", cache_dir)
+    pass

--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -19,13 +19,25 @@ class GPT2LMScorer(TransformersLMScorer):
         # sentence ends; pass eos=False to omit it from the score (see #12).
         self.add_bos = options.get("bos", True)
         self.add_eos = options.get("eos", True)
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
+
+        # Forward any remaining options to the Hugging Face loaders so callers
+        # can pass e.g. local_files_only, revision, cache_dir, token or
+        # torch_dtype (see #8).
+        hf_kwargs = {
+            key: value
+            for key, value in options.items()
+            if key not in ("batch_size", "device", "bos", "eos")
+        }
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name, **{"use_fast": True, **hf_kwargs}
+        )
         # Add the pad token to GPT2 dictionary.
         # len(tokenizer) = vocab_size + 1
         self.tokenizer.add_special_tokens({"additional_special_tokens": ["<|pad|>"]})
         self.tokenizer.pad_token = "<|pad|>"
 
-        self.model = GPT2LMHeadModel.from_pretrained(model_name)
+        self.model = GPT2LMHeadModel.from_pretrained(model_name, **hf_kwargs)
         # We need to resize the embedding layer because we added the pad token.
         self.model.resize_token_embeddings(len(self.tokenizer))
         self.model.eval()

--- a/tests/unit/models/test_gpt2.py
+++ b/tests/unit/models/test_gpt2.py
@@ -143,3 +143,24 @@ def describe_special_tokens_options():
         _, _, tokens = scorer._tokens_log_prob_for_batch(["Hello World!"])[0]
         assert "<|endoftext|>" not in tokens
         assert tokens == ["Hello", "ĠWorld", "!"]
+
+
+def describe_from_pretrained_kwargs():
+    def should_forward_extra_kwargs_to_huggingface(mocker):
+        tokenizer = mocker.patch("lm_scorer.models.gpt2.AutoTokenizer")
+        model = mocker.patch("lm_scorer.models.gpt2.GPT2LMHeadModel")
+
+        GPT2LMScorer(
+            "gpt2", revision="abc123", local_files_only=True, bos=False, batch_size=2
+        )
+
+        tok_kwargs = tokenizer.from_pretrained.call_args.kwargs
+        model_kwargs = model.from_pretrained.call_args.kwargs
+        assert tok_kwargs["revision"] == "abc123"
+        assert tok_kwargs["local_files_only"] is True
+        assert model_kwargs["revision"] == "abc123"
+        assert model_kwargs["local_files_only"] is True
+        # lm-scorer's own options must not leak to the Hugging Face loaders.
+        for own in ("bos", "eos", "device", "batch_size"):
+            assert own not in tok_kwargs
+            assert own not in model_kwargs


### PR DESCRIPTION
Forwards extra keyword arguments from `LMScorer.from_pretrained(...)` to the underlying Hugging Face loaders, so you can pass things like `local_files_only`, `revision`, `cache_dir`, `token` or `torch_dtype` (the request from #8).

- `gpt2.py`: any option that isn't one of lm-scorer's own (`device`, `batch_size`, `bos`, `eos`) is forwarded to both `AutoTokenizer.from_pretrained` and `GPT2LMHeadModel.from_pretrained`. `use_fast=True` stays the default but can be overridden.
- `transformers.py`: removed the `cache_dir` injection that was never actually forwarded (dead code) — pass `cache_dir=...` explicitly instead.
- test: mocked check that extra kwargs reach both loaders and the own options don't leak.

Verified locally: `from_pretrained("gpt2", local_files_only=True)` loads offline from cache and scores correctly; lint + unit tests green.
