### PR TITLE
docs: fix broken DOI badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@
   </a>
   <!-- DOI -->
   <a href="https://doi.org/10.5281/zenodo.20584992">
-    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20584992.svg" alt="DOI" />
+    <img src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20584992-blue.svg" alt="DOI" />
   </a>
 </p>
 <p align="center">


### PR DESCRIPTION
The Zenodo badge URL is a valid SVG, but GitHub's camo image proxy can't reliably fetch from `zenodo.org`, so the badge rendered as a broken image. Switches to an `img.shields.io` static DOI badge (camo-reliable, and matches the other shields badges). It still links to the concept DOI `10.5281/zenodo.20584992`.