### PR TITLE
ci: pin release-please baseline to the 0.5.0 release commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "cd4435214f3af2a414a4ecce314cdc77a7ddc32d",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
Fixes the duplicate 0.5.0 release PR (#26).

After #23 switched to v-prefixed tags, release-please no longer matched the existing `lm-scorer-v0.5.0` tag and proposed re-releasing 0.5.0. Pinning `last-release-sha` to the 0.5.0 release commit (`cd44352`) tells release-please 0.5.0 is already out, so it counts commits after it (the `feat` from #24) and proposes **0.6.0** next.

After merging this, release-please should replace #26 with a 0.6.0 release PR. **Don't merge #26.**