### PR TITLE
chore: migrate to ruff and refresh dev tooling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Black & Pylint & Mypy
+    name: Ruff & Mypy
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install dependencies
@@ -22,11 +22,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install
-      - name: Check if files are correctly formatted with black
-        run: poetry run task format --check --diff
-      - name: Lint with pylint
-        run: |
-          poetry run task lint --disable=E --exit-zero
-          poetry run task lint -E
+      - name: Lint with ruff
+        run: poetry run task lint
+      - name: Check formatting with ruff
+        run: poetry run ruff format --check lm_scorer tests
       - name: Perform static type checking with mypy
         run: poetry run task types

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,9 +23,9 @@ jobs:
       # done in the same job because a release created with GITHUB_TOKEN does not
       # trigger a separate `on: release` workflow. (Zenodo still mints the DOI
       # from the release webhook, independently of Actions.)
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: ${{ steps.release.outputs.release_created }}
         with:
           python-version: '3.13'

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -18,13 +18,13 @@ jobs:
       HF_HOME: ${{ github.workspace }}/.hf_home
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache huggingface models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.hf_home
           key: hf-home-${{ runner.os }}

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -18,13 +18,13 @@ jobs:
       HF_HOME: ${{ github.workspace }}/.hf_home
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache huggingface models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.hf_home
           key: hf-home-${{ runner.os }}

--- a/lm_scorer/bin/cli.py
+++ b/lm_scorer/bin/cli.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 
-from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
-
 import argparse
 import itertools
 import os
 import sys
+from typing import Generator, Iterable, List, TypeVar
 
 import torch
 
@@ -103,11 +102,11 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("The number of significant figures must be positive.")
 
 
-T1 = TypeVar("T1")  # pylint: disable=invalid-name
+T1 = TypeVar("T1")
 
 
 def grouper(iterable: Iterable[T1], size: int) -> Generator[List[T1], None, None]:
-    it = iter(iterable)  # pylint: disable=invalid-name
+    it = iter(iterable)
     while True:
         chunk = list(itertools.islice(it, size))
         if not chunk:
@@ -116,7 +115,6 @@ def grouper(iterable: Iterable[T1], size: int) -> Generator[List[T1], None, None
 
 
 def main(args: argparse.Namespace) -> None:
-    # pylint: disable=too-many-locals
     if args.sentences_file_path == "-":
         sentences_stream = sys.stdin
     else:
@@ -162,7 +160,7 @@ def run() -> None:
         main(args)
     except KeyboardInterrupt:
         print("\nAborted!")
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as err:
         if args.debug:
             raise
         print("Error: %s" % err)

--- a/lm_scorer/models/abc/base.py
+++ b/lm_scorer/models/abc/base.py
@@ -1,7 +1,6 @@
-from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from abc import ABC, abstractmethod
-
 import math
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterable, List, Tuple, Union, cast, overload
 
 import torch
 
@@ -63,7 +62,9 @@ class LMScorer(ABC):
         self, text: List[str], log: bool = False
     ) -> List[Tuple[List[float], List[int], List[str]]]: ...
 
-    def tokens_score(self, text: Union[str, List[str]], log: bool = False) -> Union[
+    def tokens_score(
+        self, text: Union[str, List[str]], log: bool = False
+    ) -> Union[
         Tuple[List[float], List[int], List[str]],
         List[Tuple[List[float], List[int], List[str]]],
     ]:
@@ -85,7 +86,6 @@ class LMScorer(ABC):
         return cls._supported_model_names()
 
     def _build(self, model_name: str, options: Dict[str, Any]) -> None:
-        # pylint: disable=attribute-defined-outside-init, unused-argument
         self.model_name = model_name
 
     @abstractmethod

--- a/lm_scorer/models/abc/batch.py
+++ b/lm_scorer/models/abc/batch.py
@@ -1,6 +1,5 @@
-# pylint: disable=abstract-method
-from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from abc import abstractmethod
+from typing import Any, Dict, List, Tuple
 
 import torch
 
@@ -15,7 +14,6 @@ class BatchedLMScorer(LMScorer):
         batch_size = options.get("batch_size", 1)
         if batch_size < 1:
             raise ValueError("The batch_size option must be positive")
-        # pylint: disable=attribute-defined-outside-init
         self.batch_size = batch_size
 
     # @overrides

--- a/lm_scorer/models/abc/transformers.py
+++ b/lm_scorer/models/abc/transformers.py
@@ -1,4 +1,3 @@
-# pylint: disable=abstract-method
 from .batch import BatchedLMScorer
 
 

--- a/lm_scorer/models/auto.py
+++ b/lm_scorer/models/auto.py
@@ -1,6 +1,5 @@
-from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
-
 import itertools
+from typing import Any, Iterable
 
 from .abc.base import LMScorer
 from .gpt2 import GPT2LMScorer

--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -1,9 +1,7 @@
-from typing import *  # pylint: disable=wildcard-import,unused-wildcard-import
-
+from typing import Any, Dict, Iterable, List, Tuple, cast
 
 import torch
-from transformers import AutoTokenizer, GPT2LMHeadModel
-from transformers import BatchEncoding
+from transformers import AutoTokenizer, BatchEncoding, GPT2LMHeadModel
 
 from .abc.transformers import TransformersLMScorer
 
@@ -13,7 +11,6 @@ class GPT2LMScorer(TransformersLMScorer):
     def _build(self, model_name: str, options: Dict[str, Any]) -> None:
         super()._build(model_name, options)
 
-        # pylint: disable=attribute-defined-outside-init
         # Whether to prepend/append the bos/eos tokens when scoring. Appending
         # the eos token (the default) also scores the probability that the
         # sentence ends; pass eos=False to omit it from the score (see #12).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ packages = [
 lm-scorer = 'lm_scorer.bin.cli:run'
 
 [tool.taskipy.tasks]
-lint = "python -m pylint lm_scorer tests -v --output-format colorized --disable duplicate-code --generated-members=torch.*"
+lint = "ruff check lm_scorer tests"
 types = "python -m mypy lm_scorer tests --ignore-missing-imports"
-format = "python -m black lm_scorer tests"
+format = "ruff format lm_scorer tests"
 test = "python -m pytest --cov=lm_scorer tests --verbose"
 
 [tool.poetry.dependencies]
@@ -28,10 +28,9 @@ python = ">=3.11,<4.0"
 transformers = ">=4.30,<6"
 torch = "^2.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 taskipy = "^1.12"
-black = "^26.0"
-pylint = "^3.1"
+ruff = "^0.15"
 mypy = "^1.9"
 pytest = "^8.1"
 pytest-cov = "^5.0"
@@ -40,6 +39,12 @@ pytest-sugar = "^1.0"
 pytest-describe = "^2.2"
 scipy = "^1.11"
 torch = "^2.2"
+
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+extend-select = ["I"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/readme.md
+++ b/readme.md
@@ -23,16 +23,12 @@
     <img src="https://github.com/simonepri/lm-scorer/actions/workflows/test-ubuntu.yml/badge.svg" alt="Test Ubuntu status" />
   </a>
   <br />
-  <!-- Code style -->
-  <a href="https://github.com/ambv/black">
-    <img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style" />
-  </a>
-  <!-- Linter -->
-  <a href="https://github.com/PyCQA/pylint">
-    <img src="https://img.shields.io/badge/linter-pylint-ce963f.svg" alt="Linter" />
+  <!-- Linter & formatter -->
+  <a href="https://github.com/astral-sh/ruff">
+    <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff" />
   </a>
   <!-- Types checker -->
-  <a href="https://github.com/PyCQA/pylint">
+  <a href="https://github.com/python/mypy">
     <img src="https://img.shields.io/badge/types%20checker-mypy-296db2.svg" alt="Types checker" />
   </a>
   <!-- Test runner -->

--- a/tests/integration/test_gpt2.py
+++ b/tests/integration/test_gpt2.py
@@ -1,6 +1,3 @@
-# pylint: disable=missing-module-docstring,missing-function-docstring,unused-variable,too-many-locals,too-many-statements
-import pytest  # pylint: disable=unused-import
-
 from lm_scorer.models.gpt2 import GPT2LMScorer
 
 

--- a/tests/unit/models/abc/test_base.py
+++ b/tests/unit/models/abc/test_base.py
@@ -1,9 +1,8 @@
-# pylint: disable=missing-module-docstring,missing-function-docstring,unused-variable,too-many-locals,too-many-statements
 import math
-import pytest  # pylint: disable=unused-import
 
 import scipy.stats
 import torch
+
 from lm_scorer.models.abc.base import LMScorer
 
 
@@ -19,9 +18,7 @@ class FixtureLMScorer(LMScorer):
         outputs = []
         for sentence in text:
             scores, ids, tokens = model(sentence)
-            # pylint: disable=not-callable
             scores = torch.tensor(scores)
-            # pylint: disable=not-callable
             ids = torch.tensor(ids)
             output = (scores, ids, tokens)
             outputs.append(output)
@@ -47,10 +44,8 @@ class FixtureLMScorer(LMScorer):
             elif reduce == "mean":
                 score = probs.mean()
             elif reduce == "gmean":
-                # pylint: disable=not-callable
                 score = torch.tensor(scipy.stats.gmean(probs.numpy()))
             elif reduce == "hmean":
-                # pylint: disable=not-callable
                 score = torch.tensor(scipy.stats.hmean(probs.numpy()))
             else:
                 raise ValueError("Unrecognized scoring strategy: %s" % reduce)

--- a/tests/unit/models/abc/test_batch.py
+++ b/tests/unit/models/abc/test_batch.py
@@ -1,5 +1,4 @@
-# pylint: disable=missing-module-docstring,missing-function-docstring,unused-variable,too-many-locals,too-many-statements
-import pytest  # pylint: disable=unused-import
+import pytest
 
 from lm_scorer.models.abc.batch import BatchedLMScorer
 

--- a/tests/unit/models/test_auto.py
+++ b/tests/unit/models/test_auto.py
@@ -1,5 +1,4 @@
-# pylint: disable=missing-module-docstring,missing-function-docstring,unused-variable,too-many-locals,too-many-statements
-import pytest  # pylint: disable=unused-import
+import pytest
 
 from lm_scorer.models.auto import AutoLMScorer
 from lm_scorer.models.gpt2 import GPT2LMScorer

--- a/tests/unit/models/test_gpt2.py
+++ b/tests/unit/models/test_gpt2.py
@@ -1,6 +1,6 @@
-# pylint: disable=missing-module-docstring,missing-function-docstring,unused-variable,too-many-locals,too-many-statements
 import math
-import pytest  # pylint: disable=unused-import
+
+import pytest
 
 from lm_scorer.models.gpt2 import GPT2LMScorer
 
@@ -20,7 +20,6 @@ def describe_supported_model_names():
 
 
 def describe_tokens_log_prob_for_batch():
-    # pylint: disable=protected-access
     scorer = GPT2LMScorer("gpt2")
 
     def should_work_on_zero_sentences():
@@ -132,7 +131,6 @@ def describe_tokens_log_prob_for_batch():
 
 
 def describe_special_tokens_options():
-    # pylint: disable=protected-access
     def should_include_the_eos_token_by_default():
         scorer = GPT2LMScorer("gpt2")
         _, _, tokens = scorer._tokens_log_prob_for_batch(["Hello World!"])[0]


### PR DESCRIPTION
Migrates dev tooling from black + pylint to **ruff**, and refreshes other stale tooling.

- **ruff** replaces black (`ruff format`) and pylint (`ruff check`); mypy stays for type checking. The taskipy `format`/`lint` tasks and the lint workflow are updated accordingly.
- Converted `from typing import *` to explicit imports and removed the now-dead `# pylint:` comments across the codebase (ruff flags star imports).
- Migrated the deprecated `[tool.poetry.dev-dependencies]` to `[tool.poetry.group.dev.dependencies]`.
- Bumped `actions/checkout` → v6, `actions/setup-python` → v6, `actions/cache` → v5 (clears most of the Node 20 deprecation warnings).
- README badges: black + pylint → a single Ruff badge; fixed the mypy badge link.

Verified locally: `ruff check`, `ruff format --check`, `mypy`, and the full unit suite (19 passed, 1 xfailed) are all green.

Note: `googleapis/release-please-action` and `amannn/action-semantic-pull-request` were left as-is to avoid touching the release / PR-title pipeline here — they have a pending Node 20 deprecation worth a separate focused bump.
