### PR TITLE
fix: silence the embedding-resize log line

### DIFF
--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -36,7 +36,9 @@ class GPT2LMScorer(TransformersLMScorer):
 
         self.model = GPT2LMHeadModel.from_pretrained(model_name, **hf_kwargs)
         # We need to resize the embedding layer because we added the pad token.
-        self.model.resize_token_embeddings(len(self.tokenizer))
+        # mean_resizing=False keeps the (never-scored) pad embedding cheap to
+        # initialise and avoids a noisy transformers log line.
+        self.model.resize_token_embeddings(len(self.tokenizer), mean_resizing=False)
         self.model.eval()
         if "device" in options:
             self.model.to(options["device"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ test = "python -m pytest --cov=lm_scorer tests --verbose"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"
-transformers = ">=4.30,<6"
+transformers = ">=4.46,<6"
 torch = "^2.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The `[transformers] The new embeddings will be initialized from a multivariate normal distribution...` line comes from our `resize_token_embeddings` call after adding the `<|pad|>` token. The pad embedding is never scored (pad positions are masked and the pad logit is set to `-inf`), so its initialisation is irrelevant — passing `mean_resizing=False` silences the notice with **no change to scores** (the exact-score unit tests still pass).

The `mean_resizing` parameter was added in transformers 4.46, so the floor moves `>=4.30` → `>=4.46` (still allows 4.x and 5.x).