### PR TITLE
docs: tidy the usage examples

### DIFF
--- a/examples/lm_scorer.ipynb
+++ b/examples/lm_scorer.ipynb
@@ -217,37 +217,37 @@
         "# @markdown Number of sentences to simultaneously feed through the model.\n",
         "BATCH_SIZE = 1  #@param {type: \"number\"}\n",
         "\n",
-        "!lm-scorer -m $MODEL -r $REDUCE -b $BATCH_SIZE --cuda $CUDA -lp -t sentences.txt"
+        "!lm-scorer -m $MODEL -r $REDUCE -b $BATCH_SIZE --cuda $CUDA -t sentences.txt"
       ],
       "execution_count": 7,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
-            "I am going to run a marathon.\t-32.551\n",
-            "I\t-3.9997\n",
-            "Ġam\t-3.0501\n",
-            "Ġgoing\t-3.4329\n",
-            "Ġto\t-0.075371\n",
-            "Ġrun\t-5.6097\n",
-            "Ġa\t-1.6184\n",
-            "Ġmarathon\t-5.9767\n",
-            ".\t-2.3148\n",
-            "<|endoftext|>\t-6.4729\n",
+            "I am going to run a marathon.\t7.303e-15\n",
+            "I\t0.018321\n",
+            "Ġam\t0.047352\n",
+            "Ġgoing\t0.032295\n",
+            "Ġto\t0.92739\n",
+            "Ġrun\t0.0036627\n",
+            "Ġa\t0.19821\n",
+            "Ġmarathon\t0.0025371\n",
+            ".\t0.09879\n",
+            "<|endoftext|>\t0.0015447\n",
             "\n",
-            "I am go to run a marathon.\t-42.834\n",
-            "I\t-3.9997\n",
-            "Ġam\t-3.0501\n",
-            "Ġgo\t-10.555\n",
-            "Ġto\t-4.5773\n",
-            "Ġrun\t-6.7562\n",
-            "Ġa\t-1.872\n",
-            "Ġmarathon\t-3.8127\n",
-            ".\t-1.9487\n",
-            "<|endoftext|>\t-6.2627\n",
+            "I am go to run a marathon.\t2.4965e-19\n",
+            "I\t0.018321\n",
+            "Ġam\t0.047352\n",
+            "Ġgo\t2.6071e-05\n",
+            "Ġto\t0.010282\n",
+            "Ġrun\t0.0011635\n",
+            "Ġa\t0.15381\n",
+            "Ġmarathon\t0.02209\n",
+            ".\t0.14246\n",
+            "<|endoftext|>\t0.0019061\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
       ]
     }

--- a/readme.md
+++ b/readme.md
@@ -88,12 +88,7 @@ list(LMScorer.supported_model_names())
 # Load model to cpu or cuda
 device = "cuda:0" if torch.cuda.is_available() else "cpu"
 batch_size = 1
-scorer = LMScorer.from_pretrained("gpt2", device=device, batch_size=batch_size)
-
-# By default the bos and eos (<|endoftext|>) tokens are added when scoring, so the
-# score includes the probability that the sentence ends where it does. Pass
-# eos=False (and/or bos=False) to exclude them:
-# scorer = LMScorer.from_pretrained("gpt2", device=device, eos=False)
+scorer = LMScorer.from_pretrained("gpt2", device=device, batch_size=batch_size, eos=True)
 
 # Return token probabilities (provide log=True to return log probabilities)
 scorer.tokens_score("I like this package.")


### PR DESCRIPTION
Two small example cleanups:

- **Example notebook**: dropped `-lp` from the demo command so it prints **probabilities** instead of log-probs — matching the README gif and far less confusing. Refreshed the saved cell output to match.
- **README**: replaced the multi-line bos/eos comment with an inline `eos=True` on the `from_pretrained` line, which surfaces the option more concisely.

No code changes.